### PR TITLE
test: workflow test with broken import

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,15 +31,17 @@ jobs:
       - name: Build images with cache
         uses: docker/bake-action@v5
         with:
-          files: tests/docker-compose.e2e.yml
+          workdir: tests
+          files: docker-compose.e2e.yml
           set: |
             *.cache-from=type=gha
             *.cache-to=type=gha,mode=max
           load: true
 
       - name: Run E2E tests
+        working-directory: tests
         run: |
-          docker compose -f tests/docker-compose.e2e.yml up --abort-on-container-exit --exit-code-from playwright
+          docker compose -f docker-compose.e2e.yml up --abort-on-container-exit --exit-code-from playwright
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
@@ -61,5 +63,6 @@ jobs:
 
       - name: Cleanup
         if: always()
+        working-directory: tests
         run: |
-          docker compose -f tests/docker-compose.e2e.yml down --volumes --remove-orphans
+          docker compose -f docker-compose.e2e.yml down --volumes --remove-orphans

--- a/tests/Dockerfile.playwright
+++ b/tests/Dockerfile.playwright
@@ -5,7 +5,7 @@ FROM mcr.microsoft.com/playwright:v1.55.0-noble
 
 WORKDIR /app
 
-# Copy package files from frontend
+# Copy package files from frontend (context is repo root)
 COPY frontend/package.json frontend/package-lock.json ./
 
 # Install dependencies

--- a/tests/docker-compose.e2e.yml
+++ b/tests/docker-compose.e2e.yml
@@ -9,7 +9,7 @@
 services:
   backend:
     build:
-      context: .
+      context: ..
       dockerfile: tests/Dockerfile.backend
     ports:
       - "8000:8000"
@@ -29,7 +29,7 @@ services:
 
   frontend:
     build:
-      context: frontend
+      context: ../frontend
       dockerfile: Dockerfile
     ports:
       - "5173:5173"
@@ -49,7 +49,7 @@ services:
 
   playwright:
     build:
-      context: .
+      context: ..
       dockerfile: tests/Dockerfile.playwright
     environment:
       - CI=true
@@ -61,8 +61,8 @@ services:
         condition: service_healthy
     volumes:
       # Mount test results for artifact collection
-      - frontend/playwright-report:/app/playwright-report
-      - frontend/test-results:/app/test-results
+      - ../frontend/playwright-report:/app/playwright-report
+      - ../frontend/test-results:/app/test-results
     networks:
       - e2e-network
 


### PR DESCRIPTION
## Summary
- Testing CI/CD workflow by intentionally breaking the build
- Added broken import to verify tests catch it

## Test plan
- [x] Push broken code
- [ ] Verify CI fails
- [ ] Fix the broken import
- [ ] Verify CI passes